### PR TITLE
Fix script loading and add simple gameplay

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,8 +6,22 @@
     <title>PxValley Game</title>
 </head>
 <body>
+    <style>
+        body { margin: 0; overflow: hidden; }
+        #score {
+            position: absolute;
+            left: 10px;
+            top: 10px;
+            color: #fff;
+            font-family: sans-serif;
+            background: rgba(0,0,0,0.5);
+            padding: 4px 8px;
+            border-radius: 4px;
+        }
+    </style>
     <canvas id="gameCanvas"></canvas>
-    <script src="index.js"></script>
+    <div id="score">Score: 0</div>
     <script src="data/collisions.js"></script>
+    <script src="index.js"></script>
 </body>
 </html>

--- a/index.js
+++ b/index.js
@@ -44,8 +44,14 @@ collisionsMap.forEach((row, i) => {
 const backgroundImg = new Image();
 backgroundImg.src = './Img/PxValleyGameMap.png';
 
-const playerImage = new Image();
-playerImage.src = './Img/playerDown.png';
+const playerDownImage = new Image();
+playerDownImage.src = './Img/playerDown.png';
+const playerUpImage = new Image();
+playerUpImage.src = './Img/playerUp.png';
+const playerLeftImage = new Image();
+playerLeftImage.src = './Img/playerLeft.png';
+const playerRightImage = new Image();
+playerRightImage.src = './Img/playerRight.png';
 
 class Sprite {
     constructor({ position, image }) {
@@ -57,6 +63,39 @@ class Sprite {
     }
 }
 
+class Player extends Sprite {
+    constructor(options) {
+        super(options);
+        this.frame = 0;
+        this.frameElapsed = 0;
+        this.frameLimit = 4;
+        this.sprites = options.sprites;
+    }
+    update() {
+        this.frameElapsed++;
+        if (this.frameElapsed % 10 === 0) {
+            this.frame = (this.frame + 1) % this.frameLimit;
+        }
+        this.draw();
+    }
+    draw() {
+        const frameWidth = this.image.width / this.frameLimit;
+        this.width = frameWidth;
+        this.height = this.image.height;
+        ctx.drawImage(
+            this.image,
+            frameWidth * this.frame,
+            0,
+            frameWidth,
+            this.image.height,
+            this.position.x - frameWidth / 2,
+            this.position.y - this.image.height / 2,
+            frameWidth,
+            this.image.height
+        );
+    }
+}
+
 const background = new Sprite({
     position: {
         x: offset.x,
@@ -64,6 +103,36 @@ const background = new Sprite({
     },
     image: backgroundImg
 });
+
+const player = new Player({
+    position: {
+        x: canvas.width / 2,
+        y: canvas.height / 2
+    },
+    image: playerDownImage,
+    sprites: {
+        up: playerUpImage,
+        down: playerDownImage,
+        left: playerLeftImage,
+        right: playerRightImage
+    }
+});
+
+const movables = [background];
+boundaries.forEach(b => movables.push(b));
+movables.push(coin);
+
+let score = 0;
+const scoreEl = document.getElementById('score');
+
+const coin = { position: { x: 0, y: 0 }, radius: 10 };
+function placeCoin() {
+    const mapWidth = collisionsMap[0].length * Boundary.width;
+    const mapHeight = collisionsMap.length * Boundary.height;
+    coin.position.x = offset.x + Math.random() * mapWidth;
+    coin.position.y = offset.y + Math.random() * mapHeight;
+}
+placeCoin();
 
 const keys = {
     w: { pressed: false },
@@ -87,17 +156,36 @@ function animate() {
     boundaries.forEach(boundary => {
         boundary.draw();
     });
-    ctx.drawImage(
-        playerImage,
-        0,
-        0,
-        playerImage.width / 4,
-        playerImage.height,
-        canvas.width / 2 - playerImage.width / 8,
-        canvas.height / 2 - playerImage.height / 2,
-        playerImage.width / 4,
-        playerImage.height
-    );
+    ctx.fillStyle = 'gold';
+    ctx.beginPath();
+    ctx.arc(coin.position.x, coin.position.y, coin.radius, 0, Math.PI * 2);
+    ctx.fill();
+    player.update();
+
+    if (
+        rectangularCollision({
+            rectangle1: {
+                position: {
+                    x: player.position.x - player.width / 2,
+                    y: player.position.y - player.height / 2
+                },
+                width: player.width,
+                height: player.height
+            },
+            rectangle2: {
+                position: {
+                    x: coin.position.x - coin.radius,
+                    y: coin.position.y - coin.radius
+                },
+                width: coin.radius * 2,
+                height: coin.radius * 2
+            }
+        })
+    ) {
+        score++;
+        scoreEl.textContent = `Score: ${score}`;
+        placeCoin();
+    }
 
     let moving = true;
     if (keys.w.pressed && lastKey === 'w') {
@@ -109,7 +197,7 @@ function animate() {
                 moving = false;
             }
         });
-        if (moving) background.position.y += 3;
+        if (moving) movables.forEach(m => m.position.y += 3);
     } else if (keys.a.pressed && lastKey === 'a') {
         boundaries.forEach(boundary => {
             if (rectangularCollision({
@@ -119,7 +207,7 @@ function animate() {
                 moving = false;
             }
         });
-        if (moving) background.position.x += 3;
+        if (moving) movables.forEach(m => m.position.x += 3);
     } else if (keys.s.pressed && lastKey === 's') {
         boundaries.forEach(boundary => {
             if (rectangularCollision({
@@ -129,7 +217,7 @@ function animate() {
                 moving = false;
             }
         });
-        if (moving) background.position.y -= 3;
+        if (moving) movables.forEach(m => m.position.y -= 3);
     } else if (keys.d.pressed && lastKey === 'd') {
         boundaries.forEach(boundary => {
             if (rectangularCollision({
@@ -139,7 +227,7 @@ function animate() {
                 moving = false;
             }
         });
-        if (moving) background.position.x -= 3;
+        if (moving) movables.forEach(m => m.position.x -= 3);
     }
 }
 
@@ -151,18 +239,26 @@ window.addEventListener('keydown', (e) => {
         case 'w':
             keys.w.pressed = true;
             lastKey = 'w';
+            player.image = player.sprites.up;
+            player.frame = 0;
             break;
         case 'a':
             keys.a.pressed = true;
             lastKey = 'a';
+            player.image = player.sprites.left;
+            player.frame = 0;
             break;
         case 's':
             keys.s.pressed = true;
             lastKey = 's';
+            player.image = player.sprites.down;
+            player.frame = 0;
             break;
         case 'd':
             keys.d.pressed = true;
             lastKey = 'd';
+            player.image = player.sprites.right;
+            player.frame = 0;
             break;
     }
 });


### PR DESCRIPTION
## Summary
- fix script order so collision data loads first
- center player with orientation sprites
- move entire world on player input
- add basic coin collecting mechanic with score display

## Testing
- `node --check index.js`

------
https://chatgpt.com/codex/tasks/task_e_6844d82d33488331b54c9cba646df7f8